### PR TITLE
add drag & drop, cleanup the code a bit

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,24 +8,24 @@
   </head>
   <body>
     <div id="app">
-      Hey there! Why not pick an image to upload to web3.storage?
+      <div id="drop-area">
+        <form id="inputs">
 
-      <div id="inputs">
-        <label for="file-input">Select an image file</label>
-        <input type="file" id="file-input" accept=".jpeg,.jpg,.png,.gif,image/*" />
+          <!-- The label for the hidden file input is styled as a button and can be clicked to select a file -->
+          <label class="select-button" for="file-input">Select an image file</label>
+          <input hidden="true" type="file" id="file-input" accept=".jpeg,.jpg,.png,.gif,image/*" />
 
-        <img id="image-preview" />
+          <img id="image-preview" />
 
-        <input id="caption-input" placeholder="Enter a caption"/>
+          <label for="caption-input">Enter a caption</label>
+          <input id="caption-input" placeholder="Enter a caption"/>
 
-        <button id="upload-button" hidden="true">Do the thing</button>
+          <button id="upload-button" disabled="true">Do the thing</button>
+        </form>
       </div>
 
-      <div id="progress">
+      <div id="output">
       </div>
-
-
-
     </div>
     <script type="module" src="/main.js"></script>
   </body>

--- a/main.js
+++ b/main.js
@@ -164,7 +164,5 @@ function showLink (url) {
   output.appendChild(node)
 }
 
-// #endregion output helpers
-
 // call the setup function
 setup()

--- a/main.js
+++ b/main.js
@@ -4,58 +4,97 @@ import { Web3Storage } from 'web3.storage'
 const WEB3STORAGE_TOKEN = import.meta.env.VITE_WEB3STORAGE_TOKEN
 const WEB3STORAGE_ENDPOINT = import.meta.env.DEV ? 'https://api-staging.web3.storage' : undefined
 
-console.log('token:', WEB3STORAGE_TOKEN)
-
 const web3storage = new Web3Storage({ token: WEB3STORAGE_TOKEN, endpoint: WEB3STORAGE_ENDPOINT })
 
+const previewImage = document.getElementById('image-preview')
+const uploadButton = document.getElementById('upload-button')
+const fileInput = document.getElementById('file-input')
+const dropArea = document.getElementById('drop-area')
+const captionInput = document.getElementById('caption-input') 
+const output = document.getElementById('output')
+
+/**
+ * Stores a file on Web3.Storage, using the provided caption as the upload name.
+ * @param {File} imageFile 
+ * @param {string} caption 
+ * @returns {object}
+ */
 async function storeImage(imageFile, caption) {
   console.log(`storing file ${imageFile.name}`)
-  const cid = await web3storage.put([imageFile], { name: caption })
-  console.log(`stored ${imageFile.name} - cid: ${cid}`)
+  const cid = await web3storage.put([imageFile], {
+    // the name is viewable at https://web3.storage/files and is included in the status and list API responses
+    name: caption,
+
+    // onRootCidReady will be called as soon as we've calculated the Content ID locally, before uploading
+    onRootCidReady: (localCid) => {
+      showMessage(`> 🔑 locally calculated Content ID: ${localCid} `)
+      showMessage('> 📡 sending files to web3.storage ')
+    },
+
+    // onStoredChunk is called after each chunk of data is uploaded
+    onStoredChunk: (bytes) => showMessage(`> 🛰 sent ${bytes.toLocaleString()} bytes to web3.storage`)
+  })
 
   const gatewayURL = `https://${cid}.ipfs.dweb.link/${imageFile.name}`
   const uri = `ipfs://${cid}/${imageFile.name}`
   return { cid, uri, gatewayURL }
 }
 
-function setImagePreview(previewURL) {
-  const img = document.getElementById('image-preview')
-  img.src = previewURL
-}
-
-function setUploadButtonEnabled(enabled) {
-  const button = document.getElementById('upload-button')
-  button.hidden = !enabled
-}
-
+/**
+ * Returns the currently selected file, or null if nothing has been selected.
+ * @returns {File|null}
+ */
 function getSelectedFile() {
-  const input = document.getElementById('file-input')
-  const files = input.files
-  if (files.length < 1) {
+  if (fileInput.files.length < 1) {
     console.log('nothing selected')
     return null
   }
-  return files[0]
+  return fileInput.files[0]
 }
 
+/**
+ * Callback for file input onchange event, fired when the user makes a file selection.
+ */
 function fileSelected() {
   const file = getSelectedFile()
-  if (file == null) {
-    console.log('nothing selected')
-    setUploadButtonEnabled(false)
+  handleFileSelected(file)
+}
+
+/**
+ * Callback for 'drop' event that fires when user drops a file onto the drop-area div.
+ * Note: currently doesn't check if the file is an image before accepting.
+ */
+ function fileDropped(evt) {
+  evt.preventDefault()
+  fileInput.files = evt.dataTransfer.files
+  const files = [...evt.dataTransfer.files]
+  if (files.length < 1) {
+    console.log('drop handler recieved no files, ignoring drop event')
     return
   }
-  const previewURL = URL.createObjectURL(file)
-  setImagePreview(previewURL)
-  setUploadButtonEnabled(true)
+  handleFileSelected(files[0])
 }
 
-function getCaption() {
-  const captionInput = document.getElementById('caption-input')
-  return captionInput.value || ''
+/**
+ * Respond to file selection, whether through drag-and-drop or manual selection.
+ * Side effects: sets preview image to file content and sets upload button state to enabled.
+ */
+function handleFileSelected(file) {
+  if (file == null) {
+    uploadButton.disabled = true
+    return
+  }
+  previewImage.src = URL.createObjectURL(file)
+  uploadButton.disabled = false
 }
 
+/**
+ * Callback for upload button's onclick event. Calls storeImage with user selected file and caption text.
+ * @param {Event} evt 
+ * @returns 
+ */
 function uploadClicked(evt) {
+  evt.preventDefault()
   console.log('upload clicked')
   const file = getSelectedFile()
   if (file == null) {
@@ -63,21 +102,69 @@ function uploadClicked(evt) {
     return
   }
   
-  const caption = getCaption()
+  const caption = captionInput.value || ''
   storeImage(file, caption).then(({ cid, gatewayURL, uri }) => {
     // TODO: do something with the cid (generate sharing link, etc)
-    console.log('stored image with cid:', cid)
-    console.log('ipfs uri:', uri)
-    console.log('gateway url:', gatewayURL)
+    showMessage(`stored image with cid: ${cid}`)
+    showMessage(`ipfs uri: ${uri}`)
+    showLink(gatewayURL)
   })
 }
 
+/**
+ * Some DOM initialization stuff.
+ */
 function setup() {
-  const fileInput = document.getElementById('file-input')
+  // handle file selection changes
   fileInput.onchange = fileSelected
 
-  const uploadButton = document.getElementById('upload-button')
+  // handle upload button clicks
   uploadButton.onclick = uploadClicked
+
+  // apply highlight class when user drags over the drop-area div
+  for (const eventName of ['dragenter', 'dragover']) {
+    const highlight = e => {
+      e.preventDefault()
+      dropArea.classList.add('highlight')
+    }
+    dropArea.addEventListener(eventName, highlight, false)
+  }
+
+  // remove highlight class on drag exit
+  for (const eventName of ['dragleave', 'drop']) {
+    const unhighlight = e => {
+      e.preventDefault()
+      dropArea.classList.remove('highlight')
+    }
+    dropArea.addEventListener(eventName, unhighlight, false)
+  }
+
+  // handle dropped files
+  dropArea.addEventListener('drop', fileDropped, false)
 }
 
+/**
+ * Display a message to the user in the output area.
+ * @param {string} text 
+ */
+function showMessage (text) {
+  const node = document.createElement('div')
+  node.innerText = text
+  output.appendChild(node)
+}
+
+/**
+ * Display a URL in the output area as a clickable link.
+ * @param {string} url 
+ */
+function showLink (url) {
+  const node = document.createElement('a')
+  node.href = url
+  node.innerText = `> 🔗 ${url}`
+  output.appendChild(node)
+}
+
+// #endregion output helpers
+
+// call the setup function
 setup()

--- a/style.css
+++ b/style.css
@@ -1,10 +1,34 @@
+
+body {
+  font-size: 16px;
+  font-family: -apple-system, system-ui;
+  padding: 0;
+  margin: 0;
+}
+form {
+  width: 500px;
+  padding: 16px;
+  max-width: 100%;
+  display: block;
+  margin: 0 auto;
+  color:#333;
+}
+label {
+  display: block;
+  padding: 32px 0 8px;
+  font-weight: 700;
+}
+
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-align: center;
   color: #2c3e50;
-  margin-top: 60px;
+  position: fixed;
+  top: 0;
+  height: 80%;
+  width: 100%;
+  overflow-y: scroll;
 }
 
 #inputs {
@@ -14,4 +38,50 @@
 
 #image-preview {
   max-width: 800px;
+}
+
+#output {
+  display: block;
+  padding: 16px;
+  margin: 0;
+  color: lime;
+  background:#222;
+  font-family: Courier New, ui-monospace, monospace;
+  font-weight: 500;
+  line-height: 1.6;
+  position: fixed;
+  bottom: 0;
+  height: 20%;
+  width: 100%;
+  overflow-y: scroll;
+}
+
+#output a {
+  color: aqua
+}
+
+#drop-area {
+  border: 2px dashed #ccc;
+  border-radius: 20px;
+  width: 550px;
+  font-family: sans-serif;
+  margin: 100px auto;
+  padding: 20px;
+}
+
+#drop-area.highlight {
+  border-color: purple;
+}
+
+.select-button {
+  display: inline-block;
+  padding: 10px;
+  background: #ccc;
+  cursor: pointer;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  text-align: center;
+}
+.select-button:hover {
+  background: #ddd;
 }


### PR DESCRIPTION
This sprinkles code comments around and adds a drag-n-drop target, plus some basic styling. I also pulled in the output panel from the browser example in the web3.storage repo, since it looks pretty :)

So far you can click the button or drag an image onto the page and add a caption. When you click the button the image gets uploaded with `put` and we dump the CID and a gateway link to the output panel at the bottom of the page.

![2021-08-03 17 12 19](https://user-images.githubusercontent.com/678715/128086962-f14a3a7e-f28b-4512-a3a4-20c4a8b210f8.gif)

@terichadbourne here's what I managed to get up to today. I'm running up on the end of my day pretty soon, so maybe we can sync tomorrow morning?