### PR TITLE
Basic image listing functionality

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web3.Storage | Image gallery example</title>
+  </head>
+  <body>
+    <div id="app">
+      <div id="gallery-ui">
+        Gallery view goes here :)
+      </div>
+    </div>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/gallery.html
+++ b/gallery.html
@@ -9,7 +9,6 @@
   <body>
     <div id="app">
       <div id="gallery-ui">
-        Gallery view goes here :)
       </div>
     </div>
     <script type="module" src="/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -8,22 +8,23 @@
   </head>
   <body>
     <div id="app">
-      <div id="drop-area">
-        <form id="inputs">
+      <div id="upload-ui">
+        <div id="drop-area">
+          <form id="inputs">
 
-          <!-- The label for the hidden file input is styled as a button and can be clicked to select a file -->
-          <label class="select-button" for="file-input">Select an image file</label>
-          <input hidden="true" type="file" id="file-input" accept=".jpeg,.jpg,.png,.gif,image/*" />
+            <!-- The label for the hidden file input is styled as a button and can be clicked to select a file -->
+            <label class="select-button" for="file-input">Select an image file</label>
+            <input hidden="true" type="file" id="file-input" accept=".jpeg,.jpg,.png,.gif,image/*" />
 
-          <img id="image-preview" />
+            <img id="image-preview" />
 
-          <label for="caption-input">Enter a caption</label>
-          <input id="caption-input" placeholder="Enter a caption"/>
+            <label for="caption-input">Enter a caption</label>
+            <input id="caption-input" placeholder="Enter a caption"/>
 
-          <button id="upload-button" disabled="true">Do the thing</button>
-        </form>
+            <button id="upload-button" disabled="true">Do the thing</button>
+          </form>
+        </div>
       </div>
-
       <div id="output">
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "version": "0.0.0",
       "dependencies": {
-        "web3.storage": "^3.0.0"
+        "web3.storage": "^3.1.0"
       },
       "devDependencies": {
         "stylus": "^0.54.8",
@@ -1879,6 +1879,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-link-header": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
+      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "dependencies": {
+        "xtend": "~4.0.1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2483,9 +2491,9 @@
       }
     },
     "node_modules/web3.storage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/web3.storage/-/web3.storage-3.0.0.tgz",
-      "integrity": "sha512-XpdXACc87KdxMY34rVfbw1171TuQeV2Vie7aHlBFY7fpSatM7pKERqP+dv7pToTDlCprrYWatH/fyc5aCAMLxg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/web3.storage/-/web3.storage-3.1.0.tgz",
+      "integrity": "sha512-CdxoQ4WKvXQMx2Hw7MOdCUOmwSpCdtOX+XI86EbiFwldXA3KmFdwF1b/VeYpQpKHEnheoANrO/owRujj3M22FQ==",
       "dependencies": {
         "@ipld/car": "^3.1.4",
         "@web-std/blob": "^2.1.0",
@@ -2496,6 +2504,7 @@
         "files-from-path": "^0.2.0",
         "ipfs-car": "^0.5.3",
         "p-retry": "^4.5.0",
+        "parse-link-header": "^1.0.1",
         "streaming-iterables": "^6.0.0"
       }
     },
@@ -2539,6 +2548,14 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -4004,6 +4021,14 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parse-link-header": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
+      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "requires": {
+        "xtend": "~4.0.1"
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4477,9 +4502,9 @@
       "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
     },
     "web3.storage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/web3.storage/-/web3.storage-3.0.0.tgz",
-      "integrity": "sha512-XpdXACc87KdxMY34rVfbw1171TuQeV2Vie7aHlBFY7fpSatM7pKERqP+dv7pToTDlCprrYWatH/fyc5aCAMLxg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/web3.storage/-/web3.storage-3.1.0.tgz",
+      "integrity": "sha512-CdxoQ4WKvXQMx2Hw7MOdCUOmwSpCdtOX+XI86EbiFwldXA3KmFdwF1b/VeYpQpKHEnheoANrO/owRujj3M22FQ==",
       "requires": {
         "@ipld/car": "^3.1.4",
         "@web-std/blob": "^2.1.0",
@@ -4490,6 +4515,7 @@
         "files-from-path": "^0.2.0",
         "ipfs-car": "^0.5.3",
         "p-retry": "^4.5.0",
+        "parse-link-header": "^1.0.1",
         "streaming-iterables": "^6.0.0"
       }
     },
@@ -4524,6 +4550,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "vite": "^2.4.3"
   },
   "dependencies": {
-    "web3.storage": "^3.0.0"
+    "web3.storage": "^3.1.0"
   }
 }

--- a/style.css
+++ b/style.css
@@ -85,3 +85,11 @@ label {
 .select-button:hover {
   background: #ddd;
 }
+
+.gallery-image-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #aaa;
+
+}


### PR DESCRIPTION
This adds a `gallery.html` page and some code to list all the images you've uploaded. Listing works by tagging our uploads with the prefix `ImageGallery` and filtering out anything from `list` without the prefix. I'm also storing a `metadata.json` file alongside the images with `path` and `caption` fields, so we can make gateway URLs for elements and show the caption.

The `setupGalleryUI` function populates the gallery page with some images:

<img width="1440" alt="Screen Shot 2021-08-04 at 2 07 24 PM" src="https://user-images.githubusercontent.com/678715/128232328-ccdb3797-2449-48fe-94f7-2c227f747461.png">

But you have to manually navigate to http://localhost:3000/gallery.html after uploading some stuff, since I haven't added any nav between pages yet.

Also @terichadbourne this commit changes the endpoint to production instead of staging - I was having a weird issue in staging where uploads weren't showing up in the list. So you'll need a production token in `.env.local` to run.