### PR TITLE
add gateway link to gallery images

### DIFF
--- a/main.js
+++ b/main.js
@@ -272,9 +272,27 @@ function uploadClicked(evt) {
 
   const label = document.createElement('span')
   label.textContent = metadata.caption
+
+  const shareLink = makeShareLink(metadata.gatewayURL)
   wrapper.appendChild(imgEl)
   wrapper.appendChild(label)
+  wrapper.appendChild(shareLink)
   return wrapper
+}
+
+function makeShareLink(url) {
+  const div = document.createElement('div')
+  div.className = 'share-link-wrapper'
+
+  const a = document.createElement('a')
+  a.href = url
+  
+  const icon = document.createElement('span')
+  icon.className = 'fontawesome-share'
+
+  a.appendChild(icon)
+  div.appendChild(a)
+  return div
 }
 
 // #endregion gallery-view


### PR DESCRIPTION
This adds an ugly "share" link to each image in the gallery that links out to the gateway URL for the image.

<img width="573" alt="Screen Shot 2021-08-06 at 1 19 13 PM" src="https://user-images.githubusercontent.com/678715/128548411-31f4cf59-3406-4867-a940-9a2354be0ed4.png">
