### PR TITLE
Fix vite build & add deploy script to deploy to web3.storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,54 @@ Open http://localhost:3000 in your browser.
 On the first run, you'll be redirected to http://localhost:3000/settings.html to paste in an API token. If you don't have a token yet, see the [Quickstart guide](https://docs.web3.storage/) to learn how to get one.
 The token is saved to your browser's local storage, so you should only need to do this once.
 
+### Building for production
+
+The commands above will run a development server that supports fancy features like hot-reloading when you change the code. This is provided by [Vite.js](https://vitejs.dev), which also bundles up the site for a production deployment.
+
+If you want to deploy the site somewhere, you can run
+
+```shell
+npm run build
+```
+
+This will create a `dist` folder with the compiled site. It will look something like this:
+
+```
+dist
+├── assets
+│   ├── favicon.17e50649.svg
+│   ├── gallery.c6431f3b.js
+│   ├── main.af36d20e.js
+│   ├── main.b06b9f34.js
+│   ├── main.b26a67ee.css
+│   ├── settings.ad3ba2b6.js
+│   └── vendor.061fb27f.js
+├── gallery.html
+├── index.html
+└── settings.html
+```
+
+The contents of the `dist` folder can be copied to any static web host, or even published to IPFS and Filecoin using Web3.Storage.
+
+<!-- TODO: write script to deploy to web3.storage & show how to use it -->
+
+To view the compiled site on your local computer, you'll need to run a basic web server - just opening the `.html` files in your browser won't work, since it will block the request to load the javascript files thanks to CORS policies.
+
+Here's a simple way to get a server running if you have `python3` installed:
+
+```shell
+cd dist
+python3 -m http.server
+```
+
+You should see something like:
+
+```
+Serving HTTP on :: port 8000 (http://[::]:8000/) ...
+```
+
+Opening http://localhost:8000 should then take you to the site.
+
 ## Code Overview
 
 This example project is written in "vanilla" JavaScript, HTML and CSS, so there's no UI framework like React or Vue in the mix, just good old `document.getElementById` and friends.

--- a/README.md
+++ b/README.md
@@ -54,20 +54,47 @@ The contents of the `dist` folder can be copied to any static web host, or even 
 
 To view the compiled site on your local computer, you'll need to run a basic web server - just opening the `.html` files in your browser won't work, since it will block the request to load the javascript files thanks to CORS policies.
 
-Here's a simple way to get a server running if you have `python3` installed:
+You can run a simple static HTTP server to preview the build output by running:
 
 ```shell
-cd dist
-python3 -m http.server
+npm run serve
 ```
 
-You should see something like:
+You should see something like this:
 
 ```
-Serving HTTP on :: port 8000 (http://[::]:8000/) ...
+> example-image-gallery@0.0.0 serve
+> vite preview
+
+
+  vite v2.4.3 build preview server running at:
+
+  > Local: http://localhost:5000/
+  > Network: use `--host` to expose
 ```
 
-Opening http://localhost:8000 should then take you to the site.
+Opening http://localhost:5000 should then take you to the site.
+
+### Deploying to Web3.Storage
+
+You can upload the compiled site directly to Web3.Storage by running:
+
+```shell
+export WEB3STORAGE_TOKEN="your-API-token"
+npm run deploy
+```
+
+You'll need to replace `your-API-token` with an API token from Web3.Storage.
+
+The [deploy script](./scripts/deploy.js) will output something similar to this:
+
+```
+Loading site files...
+Uploading 10 files to Web3.Storage...
+Deployed to Web3.Storage!
+Root cid:  bafybeifl6l3b4s7hpdm4d32vkh3gwi3cuta7owap3gooxfbrqhp7olx6m4
+Gateway url: https://bafybeifl6l3b4s7hpdm4d32vkh3gwi3cuta7owap3gooxfbrqhp7olx6m4.ipfs.dweb.link
+```
 
 ## Code Overview
 

--- a/gallery.html
+++ b/gallery.html
@@ -5,8 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Web3.Storage | Image gallery example</title>
-    <link rel="stylesheet" href="node_modules/@glidejs/glide/dist/css/glide.core.min.css">
-    <link rel="stylesheet" href="node_modules/@glidejs/glide/dist/css/glide.theme.min.css">
   </head>
   <body>
     <header>

--- a/gallery.html
+++ b/gallery.html
@@ -13,9 +13,9 @@
       </a>
       <div class="spacer"></div>
       <nav>
-        <a href="/">Upload</a>
+        <a href="./index.html">Upload</a>
         <span class="nav-current-page">Gallery</span>
-        <a href="/settings.html">Settings</a>
+        <a href="./settings.html">Settings</a>
       </nav>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
       <div class="spacer"></div>
       <nav>
         <span class="nav-current-page">Upload</span>
-        <a href="/gallery.html">Gallery</a>
-        <a href="/settings.html">Settings</a>
+        <a href="./gallery.html">Gallery</a>
+        <a href="./settings.html">Settings</a>
       </nav>
     </header>
     <div id="app">

--- a/main.js
+++ b/main.js
@@ -1,4 +1,7 @@
+import '@glidejs/glide/dist/css/glide.core.min.css'
+import '@glidejs/glide/dist/css/glide.theme.min.css'
 import './style.css'
+
 import { Web3Storage } from 'web3.storage'
 import Glide from '@glidejs/glide'
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "deploy": "npm run build && node scripts/deploy.js"
   },
   "devDependencies": {
     "stylus": "^0.54.8",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,33 @@
+// This script will upload the contents of the `dist` folder to web3.storage, so you
+// can view the application using an IPFS gateway.
+
+const fs = require('fs')
+const { Web3Storage, getFilesFromPath } = require('web3.storage')
+
+function die(message) {
+  console.error(message)
+  process.exit(1)
+}
+
+async function deploy() {
+  const { WEB3STORAGE_TOKEN } = process.env
+  if (!WEB3STORAGE_TOKEN) {
+    die('this script needs an env variable named WEB3STORAGE_TOKEN containing API token for web3.storage')
+  }
+  
+  if (!fs.existsSync('./dist')) {
+    die('dist folder not found. Try running this first: npm run build')
+  }
+  
+  const web3Storage = new Web3Storage({ token: WEB3STORAGE_TOKEN })
+  console.log('Loading site files...')
+  const files = await getFilesFromPath('./dist')
+  console.log(`Uploading ${files.length} files to Web3.Storage...`)
+  const cid = await web3Storage.put(files, { wrapWithDirectory: false })
+  console.log('Deployed to Web3.Storage!')
+  console.log('Root cid: ', cid)
+  console.log(`Gateway url: https://${cid}.ipfs.dweb.link`)
+}
+
+deploy()
+  .catch(console.error)

--- a/settings.html
+++ b/settings.html
@@ -13,8 +13,8 @@
       </a>
       <div class="spacer"></div>
       <nav>
-        <a href="/">Upload</a>
-        <a href="/gallery.html">Gallery</a>
+        <a href="./index.html">Upload</a>
+        <a href="./gallery.html">Gallery</a>
         <span class="nav-current-page">Settings</span>
       </nav>
     </header>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,13 @@
+const { resolve } = require('path')
+
+module.exports = {
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        gallery: resolve(__dirname, 'gallery.html'),
+        settings: resolve(__dirname, 'settings.html'),
+      }
+    }
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 const { resolve } = require('path')
 
 module.exports = {
+  base: '',
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
This fixes up a few things that were breaking the build when you try to compile the site for production.

As a bonus, I also added a `scripts/deploy.js` script that will upload the compiled site to web3.storage when you run `npm run deploy` 😄 

Here's an example of the deployed site: https://bafybeifl6l3b4s7hpdm4d32vkh3gwi3cuta7owap3gooxfbrqhp7olx6m4.ipfs.dweb.link
